### PR TITLE
Remove through-cargo rename of inner proc-macro crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,13 @@ readme = "README.md"
 
 [dependencies]
 
-[dependencies.proc_macro]
+[dependencies.macro_rules_attribute-proc_macro]
 version = "0.0.2"
-package = "macro_rules_attribute-proc_macro"
 path = "src/proc_macro"
 
 [features]
 nightly = []
-verbose-expansions = ["proc_macro/verbose-expansions"]
+verbose-expansions = ["macro_rules_attribute-proc_macro/verbose-expansions"]
 
 [package.metadata.docs.rs]
 features = [ "nightly" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
     cfg_attr(all(), doc = include_str!("../README.md")),
 )]
 
-extern crate proc_macro;
+extern crate macro_rules_attribute_proc_macro;
 
-pub use proc_macro::{
+pub use macro_rules_attribute_proc_macro::{
     macro_rules_attribute,
     macro_rules_derive,
 };


### PR DESCRIPTION
# Problem

When cross-compiling and depending on a Cargo-renamed pure proc-macro crate a rustc bug can sometimes be triggered which errors in unresolved imports.

In the case of `::macro_rules_attribute`, the bug amounted to the following errors:

```
error[E0432]: unresolved imports `proc_macro::macro_rules_attribute`, `proc_macro::macro_rules_derive`
  |
8 |     macro_rules_attribute,
  |     ^^^^^^^^^^^^^^^^^^^^^ no `macro_rules_attribute` in the root
9 |     macro_rules_derive,
  |     ^^^^^^^^^^^^^^^^^^ no `macro_rules_derive` in the root

```

# Solution

Undo the renaming at the `Cargo.toml` layer and instead use the full name in `src/lib.rs`. This is unfortunate, but the change is at least contained entirely within the crate.

I've confirmed with a Cargo patch that undoing these renames avoids triggering the rustc bug when cross-compiling.