### PR TITLE
Fix intra-doc links in README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.1.0"
+version = "0.1.1-rc1"
 dependencies = [
  "macro_rules_attribute-proc_macro",
  "once_cell",
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.0"
+version = "0.1.1-rc1"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.1.1-rc2"
+version = "0.1.1"
 dependencies = [
  "macro_rules_attribute-proc_macro",
  "once_cell",
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.1-rc2"
+version = "0.1.1"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.1.1-rc1"
+version = "0.1.1-rc2"
 dependencies = [
  "macro_rules_attribute-proc_macro",
  "once_cell",
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.1-rc1"
+version = "0.1.1-rc2"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_rules_attribute"
-version = "0.1.0"  # Keep in sync
+version = "0.1.1-rc1"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 
@@ -19,7 +19,7 @@ readme = "README.md"
 paste.version = "1.0.7"
 
 [dependencies.macro_rules_attribute-proc_macro]
-version = "0.1.0"  # Keep in sync
+version = "0.1.1-rc1"  # Keep in sync
 path = "src/proc_macro"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_rules_attribute"
-version = "0.1.1-rc2"  # Keep in sync
+version = "0.1.1"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 
@@ -19,7 +19,7 @@ readme = "README.md"
 paste.version = "1.0.7"
 
 [dependencies.macro_rules_attribute-proc_macro]
-version = "0.1.1-rc2"  # Keep in sync
+version = "0.1.1"  # Keep in sync
 path = "src/proc_macro"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_rules_attribute"
-version = "0.1.1-rc1"  # Keep in sync
+version = "0.1.1-rc2"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 
@@ -19,7 +19,7 @@ readme = "README.md"
 paste.version = "1.0.7"
 
 [dependencies.macro_rules_attribute-proc_macro]
-version = "0.1.1-rc1"  # Keep in sync
+version = "0.1.1-rc2"  # Keep in sync
 path = "src/proc_macro"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ for attribute-position polish!
 
 First, define the helper around, say, `OnceCell`'s `Lazy` type:
 
-```rust ,ignore
+```rust
 macro_rules! lazy_init {(
     $( #[$attrs:meta] )*
     $pub:vis
@@ -432,5 +432,3 @@ the examples.
 [apply]: https://docs.rs/macro_rules_attribute/0.1.*/macro_rules_attribute/attr.apply.html
 [derive]: https://docs.rs/macro_rules_attribute/0.1.*/macro_rules_attribute/attr.derive.html
 [`derive_alias!`]: https://docs.rs/macro_rules_attribute/0.1.*/macro_rules_attribute/macro.derive_alias.html
-[`macro_rules_attribute`]: https://docs.rs/macro_rules_attribute_proc_macro/0.1.*/macro_rules_attribute_proc_macro/attr.macro_rules_attribute.html
-[`macro_rules_derive`]: https://docs.rs/macro_rules_attribute_proc_macro/0.1.*/macro_rules_attribute_proc_macro/attr.macro_rules_derive.html

--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ With this crate's <code>#\[[apply]\]</code> and <code>#\[[derive]\]</code>
 attributes, it is now possible to use `proc_macro_attribute` syntax to apply a
 `macro_rules!` macro:
 
-[apply]: https://docs.rs/macro_rules_attribute/0.1.0-rc1/macro_rules_attribute/attr.apply.html
-[derive]: https://docs.rs/macro_rules_attribute/0.1.0-rc1/macro_rules_attribute/attr.derive.html
 
 ```rust
 #[macro_use]
@@ -117,8 +115,6 @@ struct Struct {
 without even depending on [`::quote`], [`::syn`] or [`::proc-macro2`], for
 **fast compile times**.
 
-[`macro_rules_attribute`]: https://docs.rs/macro_rules_attribute_proc_macro/0.0.1/macro_rules_attribute_proc_macro/attr.macro_rules_attribute.html
-[`macro_rules_derive`]: https://docs.rs/macro_rules_attribute_proc_macro/0.0.1/macro_rules_attribute_proc_macro/attr.macro_rules_derive.html
 [`::paste`]: https://docs.rs/paste
 [`::proc-macro2`]: https://docs.rs/proc_macro2
 [`::syn`]: https://docs.rs/syn
@@ -355,8 +351,6 @@ struct Foo {
 
   - See [`derive_alias!`] and <code>#\[[derive]\]</code> for more info.
 
-[`derive_alias!`]: https://docs.rs/macro_rules_attribute/0.1.0-rc1/macro_rules_attribute/macro.derive_alias.html
-
 ### `cfg` aliases
 
 <details><summary>Click to see</summary>
@@ -434,3 +428,9 @@ gained "namespace purity", hence my not using that pattern across the rest of
 the examples.
 
 </details>
+
+[apply]: https://docs.rs/macro_rules_attribute/0.1.*/macro_rules_attribute/attr.apply.html
+[derive]: https://docs.rs/macro_rules_attribute/0.1.*/macro_rules_attribute/attr.derive.html
+[`derive_alias!`]: https://docs.rs/macro_rules_attribute/0.1.*/macro_rules_attribute/macro.derive_alias.html
+[`macro_rules_attribute`]: https://docs.rs/macro_rules_attribute_proc_macro/0.1.*/macro_rules_attribute_proc_macro/attr.macro_rules_attribute.html
+[`macro_rules_derive`]: https://docs.rs/macro_rules_attribute_proc_macro/0.1.*/macro_rules_attribute_proc_macro/attr.macro_rules_derive.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+/*!
+[apply]: apply
+[derive]: derive
+[`derive_alias!`]: derive_alias
+[`macro_rules_attribute`]: macro_rules_attribute
+[`macro_rules_derive`]: macro_rules_derive
+*/
 #![doc = include_str!("../README.md")]
 #![cfg_attr(feature = "better-docs",
     feature(doc_auto_cfg),

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -4,7 +4,7 @@ path = "mod.rs"
 
 [package]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.1-rc1"  # Keep in sync
+version = "0.1.1-rc2"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -4,7 +4,7 @@ path = "mod.rs"
 
 [package]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.0"  # Keep in sync
+version = "0.1.1-rc1"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -4,7 +4,7 @@ path = "mod.rs"
 
 [package]
 name = "macro_rules_attribute-proc_macro"
-version = "0.1.1-rc2"  # Keep in sync
+version = "0.1.1"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
Fixes #6, at least for the docs.rs part, by abusing the current lack of shadowing of "link aliases".

  - for the Github README.md part, I've settled for `0.1.*` semver-ish links, which ensure they ought to remain not too outdated while also not getting ahead of themselves. But of course if I bump the semver I may forget to update those.

As of now, I find that this setup strikes a nice balance of robustness and implementation / maintenance cost:

  - docs.rs ought to remain correct, thence covering the major pain point.
  - for the rare cases of a major release, the links in the README may get outdated _but will remain correct_.
      - Updating those for github would only require publishing a commit;
      - but if I want those to apply to https://crates.io/crates/macro-rules-attribute, I would have to make another patch release; which is fine by me.

  - no need to be encumbered by tools such as `cargo readme`, or to write one's own `README.md.template -> README.md` script (as I once tried, only to find out that I still used to edit the `README.md` file directly, making me waste time and effort and CI safeguards).

___

### Rendered

  - [Github](https://github.com/danielhenrymantilla/macro_rules_attribute-rs/blob/691aa645dde694e3ec0f8090025df6d3e5bd0f7b/README.md)
  - [crates.io](https://crates.io/crates/macro_rules_attribute/0.1.1-rc1)
  - [docs.rs](https://docs.rs/macro_rules_attribute/0.1.1-rc1/macro_rules_attribute/index.html)