### PR TITLE
Fix SPDX license expression in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Use declarative macros in attribute or derive position"
 keywords = ["macro", "attribute", "decorator", "derive", "macro_rules"]
 categories = ["rust-patterns"]
 
-license = "MIT"
+license = "Apache-2.0 OR MIT OR Zlib"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
Per the maintainer (@danielhenrymantilla) in issue #26,
(link: https://github.com/danielhenrymantilla/macro_rules_attribute-rs/issues/26#issuecomment-2788750382 )
"Ah yes, the stale Cargo.toml entry is an oversight; it is indeed OR"

Signed-off-by: Alexander F. Lent <lx@xanderlent.com>
