### PR TITLE
Update the license metadata in the proc_macro crate

### DIFF
--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 description = "Use declarative macros as proc_macro attributes or derives"
 repository = "https://github.com/danielhenrymantilla/macro_rules_attribute-rs"
-license = "MIT"
+license = "Apache-2.0 OR MIT OR Zlib"
 
 [dependencies]
 


### PR DESCRIPTION
This is the same as ddcf04f30717c80a37911cb311dac5dc20c35ae6 in the top-level crate, but for the `macro_rules_attribute-proc_macro` crate.