### PR TITLE
replace doc_auto_cfg feature with doc_cfg feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
     cfg_attr(all(), doc = include_str!("../README.md"))
 )]
 #![cfg_attr(feature = "better-docs",
-    feature(doc_auto_cfg),
+    feature(doc_cfg),
 )]
 #![no_std]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
`doc_auto_cfg` is gone with rustc 1.92.0